### PR TITLE
Replace jeweler with bundler for building/releasing gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,42 +1,6 @@
-# encoding: utf-8
+require "bundler/gem_tasks"
 
-task :default => :test
-
-require 'jeweler'
-Jeweler::Tasks.new do |gem|
-  gem.name = "health_graph"
-  gem.homepage = "http://github.com/kennyma/health_graph"
-  gem.license = "MIT"
-  gem.summary = "Ruby gem for RunKeeper Health Graph API"
-  gem.description = "This is a wrapper for RunKeeper Health Graph RESTful API."
-  gem.email = "kenny@kennyma.me"
-  gem.authors = ["Kenny Ma"]
-
-  gem.add_dependency "oauth2", ">= 0.5.2"
-  gem.add_dependency "faraday", ">= 0.7.4"
-  gem.add_dependency "faraday_middleware", ">= 0.7.8"
-  gem.add_dependency "hashie", ">= 1.2"
-  gem.add_dependency "webmock", ">= 1.7.6"
-
-  gem.add_development_dependency "shoulda"
-  gem.add_development_dependency "simplecov"
-  gem.add_development_dependency "jeweler"
-end
-Jeweler::RubygemsDotOrgTasks.new
-
-require 'rake/testtask'
-Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
-end
-
-require 'rdoc/task'
-Rake::RDocTask.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
-
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title = "health_graph #{version}"
-  rdoc.rdoc_files.include('README*')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+desc "Run all tests"
+task :test do
+  ruby("test/test_health_graph.rb")
 end

--- a/health_graph.gemspec
+++ b/health_graph.gemspec
@@ -3,140 +3,34 @@
 # Instead, edit Jeweler::Tasks in Rakefile, and run 'rake gemspec'
 # -*- encoding: utf-8 -*-
 
-Gem::Specification.new do |s|
-  s.name = "health_graph"
-  s.version = "0.6.0"
+Gem::Specification.new do |spec|
+  spec.name = "health_graph"
+  spec.version = "0.6.0"
+  spec.authors = ["Kenny Ma"]
+  spec.email = "kenny@kennyma.me"
+  spec.date = "2012-07-17"
+  spec.description = "This is a wrapper for RunKeeper Health Graph RESTful API."
+  spec.summary = "Ruby gem for RunKeeper Health Graph API"
+  spec.homepage = "http://github.com/kennyma/health_graph"
+  spec.licenses = ["MIT"]
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Kenny Ma"]
-  s.date = "2012-07-17"
-  s.description = "This is a wrapper for RunKeeper Health Graph RESTful API."
-  s.email = "kenny@kennyma.me"
-  s.extra_rdoc_files = [
+  spec.extra_rdoc_files = [
     "LICENSE.txt",
     "README.rdoc"
   ]
-  s.files = [
-    ".document",
-    "Gemfile",
-    "LICENSE.txt",
-    "README.rdoc",
-    "Rakefile",
-    "VERSION",
-    "health_graph.gemspec",
-    "lib/health_graph.rb",
-    "lib/health_graph/api.rb",
-    "lib/health_graph/authentication.rb",
-    "lib/health_graph/configuration.rb",
-    "lib/health_graph/model.rb",
-    "lib/health_graph/models/fitness_activities_feed.rb",
-    "lib/health_graph/models/fitness_activity_delete.rb",
-    "lib/health_graph/models/fitness_activity_update.rb",
-    "lib/health_graph/models/new_fitness_activity.rb",
-    "lib/health_graph/models/profile.rb",
-    "lib/health_graph/models/settings.rb",
-    "lib/health_graph/models/sleep_feed.rb",
-    "lib/health_graph/models/strength_training_activities_feed.rb",
-    "lib/health_graph/models/strength_training_activity.rb",
-    "lib/health_graph/models/user.rb",
-    "lib/health_graph/models/weight_feed.rb",
-    "test/fixtures/background_activities_feed.json",
-    "test/fixtures/background_activity.json",
-    "test/fixtures/fitness_activities_feed.json",
-    "test/fixtures/fitness_activity.json",
-    "test/fixtures/new_fitness_activity_params.json",
-    "test/fixtures/profile_get.json",
-    "test/fixtures/records.json",
-    "test/fixtures/sleep_feed_get.json",
-    "test/fixtures/team_get_empty.json",
-    "test/fixtures/user_get.json",
-    "test/fixtures/weight_feed_get.json",
-    "test/fixtures/weight_get_empty.json",
-    "test/health_graph/test_fitness_activities_feed.rb",
-    "test/health_graph/test_new_fitness_activity.rb",
-    "test/health_graph/test_profile.rb",
-    "test/health_graph/test_sleep_feed.rb",
-    "test/health_graph/test_user.rb",
-    "test/health_graph/test_weight_feed.rb",
-    "test/helper.rb",
-    "test/test_health_graph.rb"
-  ]
-  s.homepage = "http://github.com/kennyma/health_graph"
-  s.licenses = ["MIT"]
-  s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.13"
-  s.summary = "Ruby gem for RunKeeper Health Graph API"
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
+  spec.add_dependency "oauth2", ">= 0.5.2"
+  spec.add_dependency "faraday", ">= 0.7.4"
+  spec.add_dependency "faraday_middleware", ">= 0.7.8"
+  spec.add_dependency "hashie", ">= 1.2"
+  spec.add_dependency "webmock", ">= 1.7.6"
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<health_graph>, [">= 0"])
-      s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
-      s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
-      s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
-      s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
-      s.add_runtime_dependency(%q<oauth2>, [">= 0.5.2"])
-      s.add_runtime_dependency(%q<faraday>, [">= 0.7.4"])
-      s.add_runtime_dependency(%q<faraday_middleware>, [">= 0.7.8"])
-      s.add_runtime_dependency(%q<hashie>, [">= 1.2"])
-      s.add_runtime_dependency(%q<webmock>, [">= 1.7.6"])
-      s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
-    else
-      s.add_dependency(%q<health_graph>, [">= 0"])
-      s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<oauth2>, [">= 0.5.2"])
-      s.add_dependency(%q<faraday>, [">= 0.7.4"])
-      s.add_dependency(%q<faraday_middleware>, [">= 0.7.8"])
-      s.add_dependency(%q<hashie>, [">= 1.2"])
-      s.add_dependency(%q<webmock>, [">= 1.7.6"])
-      s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<health_graph>, [">= 0"])
-    s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<oauth2>, [">= 0.5.2"])
-    s.add_dependency(%q<faraday>, [">= 0.7.4"])
-    s.add_dependency(%q<faraday_middleware>, [">= 0.7.8"])
-    s.add_dependency(%q<hashie>, [">= 1.2"])
-    s.add_dependency(%q<webmock>, [">= 1.7.6"])
-    s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
-  end
+  spec.add_development_dependency "shoulda"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "pry"
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,14 +11,14 @@ require 'health_graph'
 
 class Test::Unit::TestCase
   TEST_USER_TOKEN = "b9aaf2581480432a939a72f894bf".freeze
-  
+
   def fixture(file)
     path = File.expand_path("../fixtures", __FILE__)
     File.new(path + '/' + file)
   end
-  
+
   def json_fixture(file)
     file = fixture(file)
-    JSON.load(file)    
+    JSON.load(file)
   end
 end

--- a/test/test_health_graph.rb
+++ b/test/test_health_graph.rb
@@ -1,102 +1,102 @@
-require 'helper'
+require_relative 'helper'
 
 class TestHealthGraph < Test::Unit::TestCase
-  context "Health Graph" do        
-    setup do 
+  context "Health Graph" do
+    setup do
       HealthGraph.reset
     end
-    
+
     should "get default client id" do
       assert_equal nil, HealthGraph.client_id
     end
-    
+
     should "set client id" do
       client_id = "123456asdb"
       HealthGraph.client_id = client_id
       assert_equal client_id, HealthGraph.client_id
     end
-    
+
     should "get default client secret" do
       assert_equal nil, HealthGraph.client_secret
     end
-    
+
     should "set client secret" do
       secret = "supersecret"
       HealthGraph.client_secret = secret
       assert_equal secret, HealthGraph.client_secret
     end
-    
+
     should "get default authorization url" do
       assert_equal "https://runkeeper.com/apps/authorize", HealthGraph.authorization_url
     end
-    
+
     should "set authorization url" do
       url = "http://somesite.com/apps/authorize"
       HealthGraph.authorization_url = url
       assert_equal url, HealthGraph.authorization_url
     end
-    
+
     should "get default access token url" do
       assert_equal "https://runkeeper.com/apps/token", HealthGraph.access_token_url
     end
-    
+
     should "set access token url" do
       url = "http://somesite.com/apps/token"
       HealthGraph.access_token_url = url
       assert_equal url, HealthGraph.access_token_url
     end
-      
+
     should "get default authorization redirect url" do
       assert_equal nil, HealthGraph.authorization_redirect_url
     end
-    
+
     should "set authorization redirect url" do
       url = "http://somesite.com/runkeeper"
       HealthGraph.authorization_redirect_url = url
       assert_equal url, HealthGraph.authorization_redirect_url
     end
-  
+
     should "get default api endpoint" do
       assert_equal "https://api.runkeeper.com", HealthGraph.endpoint
     end
-    
+
     should "set api endpoont" do
       new_endpoint = "https://api.somesite.com"
       HealthGraph.endpoint = new_endpoint
-      assert_equal new_endpoint, HealthGraph.endpoint      
-    end 
-    
+      assert_equal new_endpoint, HealthGraph.endpoint
+    end
+
     should "get default adapter" do
       assert_equal :net_http, HealthGraph.adapter
     end
-    
+
     should "set adapter" do
       adapter = :typhoeus
       HealthGraph.adapter = adapter
       assert_equal adapter, HealthGraph.adapter
     end
-    
+
     should "get default faraday options" do
       assert HealthGraph.faraday_options.empty?, "Expected empty hash but got #{HealthGraph.faraday_options.inspect}"
     end
-    
+
     should "set faraday options" do
       options = {:new_option => "testing option", :another => "another option"}
       HealthGraph.faraday_options = options
       assert_equal options, HealthGraph.faraday_options
     end
-    
+
     should "get default accept headers" do
       options = {
         :user => "application/vnd.com.runkeeper.User+json",
         :fitness_activity_feed => "application/vnd.com.runkeeper.FitnessActivityFeed+json",
         :fitness_activity => "application/vnd.com.runkeeper.FitnessActivity+json",
-        :new_fitness_activity => "application/vnd.com.runkeeper.NewFitnessActivity+json",      
+        :new_fitness_activity => "application/vnd.com.runkeeper.NewFitnessActivity+json",
         :strength_training_activity_feed => "application/vnd.com.runkeeper.StrengthTrainingActivityFeed+json",
-        :strength_training_activity => "application/vnd.com.runkeeper.StrengthTrainingActivity+json",    
+        :strength_training_activity => "application/vnd.com.runkeeper.StrengthTrainingActivity+json",
         :background_activity_feed => "application/vnd.com.runkeeper.BackgroundActivityFeed+json",
         :background_activity => "application/vnd.com.runkeeper.BackgroundActivity+json",
-        :sleep_feed => "application/vnd.com.runkeeper.SleepFeed+json", 
+        :sleep_feed => "application/vnd.com.runkeeper.SleepFeed+json",
         :sleep => "application/vnd.com.runkeeper.Sleep+json",
         :nutrition_feed => "application/vnd.com.runkeeper.NutritionFeed+json",
         :nutrition => "application/vnd.com.runkeeper.Nutrition+json",
@@ -105,33 +105,34 @@ class TestHealthGraph < Test::Unit::TestCase
         :general_measurement_feed => "application/vnd.com.runkeeper.GeneralMeasurementFeed+json",
         :general_measurement => "application/vnd.com.runkeeper.GeneralMeasurement+json",
         :diabetes_feed => "application/vnd.com.runkeeper.DiabetesFeed+json",
-        :diatetes_measurement => "application/vnd.com.runkeeper.DiabetesMeasurement+json",  
+        :diatetes_measurement => "application/vnd.com.runkeeper.DiabetesMeasurement+json",
         :records => "application/vnd.com.runkeeper.Records+json",
-        :profile => "application/vnd.com.runkeeper.Profile+json"
+        :profile => "application/vnd.com.runkeeper.Profile+json",
+        :settings=>"application/vnd.com.runkeeper.Settings+json"
       }
-      
+
       assert_equal options, HealthGraph.accept_headers
-    end   
-    
+    end
+
     should "set accept headers" do
       options = {
         :user => "application/vnd.com.runkeeper.User+json",
-        :fitness_activity_feed => "application/vnd.com.runkeeper.FitnessActivityFeed+json",        
+        :fitness_activity_feed => "application/vnd.com.runkeeper.FitnessActivityFeed+json",
       }
-      
+
       HealthGraph.accept_headers = options
       assert_equal options, HealthGraph.accept_headers
     end
-        
-    context "configure" do 
+
+    context "configure" do
       HealthGraph::Configuration::VALID_OPTIONS_KEYS.each do |k|
         should "set #{k}" do
           HealthGraph.configure do |config|
-            config.send("#{k}=", k)          
+            config.send("#{k}=", k)
           end
           assert_equal k, HealthGraph.send(k)
         end
-      end                
+      end
     end
   end
 end


### PR DESCRIPTION
In order to fix an issue with a circular dependency, this commit removes
jeweler from the project's development dependencies and instead uses the
built in facilities in bundler for gem building and releasing. This
commit also fixes a broken spec and adds a rake task for running specs.