### PR TITLE
rubocop --auto-correct

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 
-desc "Run all tests"
+desc 'Run all tests'
 task :test do
-  ruby("test/test_health_graph.rb")
+  ruby('test/test_health_graph.rb')
 end

--- a/health_graph.gemspec
+++ b/health_graph.gemspec
@@ -4,32 +4,33 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |spec|
-  spec.name = "health_graph"
-  spec.version = "0.7.1"
-  spec.authors = ["Kenny Ma"]
-  spec.email = "kenny@kennyma.me"
-  spec.date = "2015-12-31"
-  spec.description = "This is a wrapper for RunKeeper Health Graph RESTful API."
-  spec.summary = "Ruby gem for RunKeeper Health Graph API"
-  spec.homepage = "http://github.com/kennyma/health_graph"
-  spec.licenses = ["MIT"]
+  spec.name = 'health_graph'
+  spec.version = '0.7.1'
+  spec.authors = ['Kenny Ma']
+  spec.email = 'kenny@kennyma.me'
+  spec.date = '2015-12-31'
+  spec.description = 'This is a wrapper for RunKeeper Health Graph RESTful API.'
+  spec.summary = 'Ruby gem for RunKeeper Health Graph API'
+  spec.homepage = 'http://github.com/kennyma/health_graph'
+  spec.licenses = ['MIT']
 
   spec.extra_rdoc_files = [
-    "LICENSE.txt",
-    "README.rdoc"
+    'LICENSE.txt',
+    'README.rdoc'
   ]
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "oauth2", ">= 0.5.2"
-  spec.add_dependency "faraday", ">= 0.7.4"
-  spec.add_dependency "faraday_middleware", ">= 0.7.8"
-  spec.add_dependency "hashie", ">= 1.2"
-  spec.add_dependency "webmock", ">= 1.7.6"
+  spec.add_dependency 'oauth2', '>= 0.5.2'
+  spec.add_dependency 'faraday', '>= 0.7.4'
+  spec.add_dependency 'faraday_middleware', '>= 0.7.8'
+  spec.add_dependency 'hashie', '>= 1.2'
+  spec.add_dependency 'webmock', '>= 1.7.6'
 
-  spec.add_development_dependency "shoulda"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency 'shoulda'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rubocop'
 end

--- a/lib/health_graph.rb
+++ b/lib/health_graph.rb
@@ -17,6 +17,6 @@ require 'health_graph/models/fitness_activity_delete'
 require 'health_graph/models/settings'
 
 module HealthGraph
-  extend Configuration 
-  extend Authentication 
+  extend Configuration
+  extend Authentication
 end

--- a/lib/health_graph/api.rb
+++ b/lib/health_graph/api.rb
@@ -1,52 +1,50 @@
 module HealthGraph
   module API
     attr_accessor :access_token
-    
+
     def get(path, accept_header, params = {})
       request(:get, accept_header, path, params)
     end
-    
+
     def post(path, accept_header, params = {})
       request(:post, accept_header, path, params)
     end
-    
+
     def put(path, accept_header, params = {})
       request(:put, accept_header, path, params)
     end
-    
-    def delete(path, accept_header, params = {}) 
+
+    def delete(path, accept_header, params = {})
       request(:delete, accept_header, path, params)
     end
 
-    private 
-    
+    private
+
     def request(method, accept_header, path, params)
       response = connection(method).send(method) do |request|
         request.headers['Authorization'] = "Bearer #{access_token}"
-        
+
         case method.to_sym
         when :get, :delete
-          request.headers['Accept'] = accept_header          
+          request.headers['Accept'] = accept_header
           request.url(path, params)
         when :put, :post
           request.headers['Content-Type'] = accept_header
           request.path = path
           request.body = params.to_json unless params.empty?
-        end        
+        end
       end
       response
     end
-    
-    def connection method
-      merged_options = HealthGraph.faraday_options.merge({
-        :url => HealthGraph.endpoint
-      })
-      
+
+    def connection(method)
+      merged_options = HealthGraph.faraday_options.merge(url: HealthGraph.endpoint)
+
       Faraday.new(merged_options) do |builder|
         builder.use Faraday::Request::UrlEncoded
         builder.use FaradayMiddleware::EncodeJson if method == :post
         builder.use Faraday::Response::Mashify
-        builder.use Faraday::Response::ParseJson        
+        builder.use Faraday::Response::ParseJson
         builder.adapter(HealthGraph.adapter)
       end
     end

--- a/lib/health_graph/authentication.rb
+++ b/lib/health_graph/authentication.rb
@@ -1,15 +1,15 @@
 module HealthGraph
   module Authentication
-    def authorize_url 
-      client.auth_code.authorize_url :redirect_uri => authorization_redirect_url
+    def authorize_url
+      client.auth_code.authorize_url redirect_uri: authorization_redirect_url
     end
-    
+
     def access_token(code)
-      client.auth_code.get_token(code, :redirect_uri => authorization_redirect_url).token
+      client.auth_code.get_token(code, redirect_uri: authorization_redirect_url).token
     end
-    
-    def client 
-      OAuth2::Client.new client_id, client_secret, {:authorize_url => authorization_url, :token_url => access_token_url}
-    end   
+
+    def client
+      OAuth2::Client.new client_id, client_secret, authorize_url: authorization_url, token_url: access_token_url
+    end
   end
 end

--- a/lib/health_graph/configuration.rb
+++ b/lib/health_graph/configuration.rb
@@ -9,56 +9,57 @@ module HealthGraph
       :endpoint,
       :adapter,
       :faraday_options,
-      :accept_headers].freeze  
-  
+      :accept_headers
+    ].freeze
+
     DEFAULT_CLIENT_ID = nil
     DEFAULT_CLIENT_SECRET = nil
-    DEFAULT_AUTHORIZATION_URL = "https://runkeeper.com/apps/authorize".freeze
-    DEFAULT_ACCESS_TOKEN_URL = "https://runkeeper.com/apps/token".freeze
+    DEFAULT_AUTHORIZATION_URL = 'https://runkeeper.com/apps/authorize'.freeze
+    DEFAULT_ACCESS_TOKEN_URL = 'https://runkeeper.com/apps/token'.freeze
     DEFAULT_AUTHORIZATION_REDIRECT_URL = nil
-    DEFAULT_ENDPOINT = "https://api.runkeeper.com".freeze
+    DEFAULT_ENDPOINT = 'https://api.runkeeper.com'.freeze
     DEFAULT_ADAPTER = :net_http
     DEFAULT_FARADAY_OPTIONS = {}.freeze
     DEFAULT_ACCEPT_HEADERS = {
-      :user => "application/vnd.com.runkeeper.User+json",
-      :fitness_activity_feed => "application/vnd.com.runkeeper.FitnessActivityFeed+json",
-      :fitness_activity => "application/vnd.com.runkeeper.FitnessActivity+json",
-      :new_fitness_activity => "application/vnd.com.runkeeper.NewFitnessActivity+json",      
-      :strength_training_activity_feed => "application/vnd.com.runkeeper.StrengthTrainingActivityFeed+json",
-      :strength_training_activity => "application/vnd.com.runkeeper.StrengthTrainingActivity+json",    
-      :background_activity_feed => "application/vnd.com.runkeeper.BackgroundActivityFeed+json",
-      :background_activity => "application/vnd.com.runkeeper.BackgroundActivity+json",
-      :sleep_feed => "application/vnd.com.runkeeper.SleepFeed+json", 
-      :sleep => "application/vnd.com.runkeeper.Sleep+json",
-      :nutrition_feed => "application/vnd.com.runkeeper.NutritionFeed+json",
-      :nutrition => "application/vnd.com.runkeeper.Nutrition+json",
-      :weight_feed => "application/vnd.com.runkeeper.WeightFeed+json",
-      :weight => "application/vnd.com.runkeeper.Weight+json",
-      :general_measurement_feed => "application/vnd.com.runkeeper.GeneralMeasurementFeed+json",
-      :general_measurement => "application/vnd.com.runkeeper.GeneralMeasurement+json",
-      :diabetes_feed => "application/vnd.com.runkeeper.DiabetesFeed+json",
-      :diatetes_measurement => "application/vnd.com.runkeeper.DiabetesMeasurement+json",  
-      :records => "application/vnd.com.runkeeper.Records+json",
-      :profile => "application/vnd.com.runkeeper.Profile+json",
-      :settings => "application/vnd.com.runkeeper.Settings+json"
+      user: 'application/vnd.com.runkeeper.User+json',
+      fitness_activity_feed: 'application/vnd.com.runkeeper.FitnessActivityFeed+json',
+      fitness_activity: 'application/vnd.com.runkeeper.FitnessActivity+json',
+      new_fitness_activity: 'application/vnd.com.runkeeper.NewFitnessActivity+json',
+      strength_training_activity_feed: 'application/vnd.com.runkeeper.StrengthTrainingActivityFeed+json',
+      strength_training_activity: 'application/vnd.com.runkeeper.StrengthTrainingActivity+json',
+      background_activity_feed: 'application/vnd.com.runkeeper.BackgroundActivityFeed+json',
+      background_activity: 'application/vnd.com.runkeeper.BackgroundActivity+json',
+      sleep_feed: 'application/vnd.com.runkeeper.SleepFeed+json',
+      sleep: 'application/vnd.com.runkeeper.Sleep+json',
+      nutrition_feed: 'application/vnd.com.runkeeper.NutritionFeed+json',
+      nutrition: 'application/vnd.com.runkeeper.Nutrition+json',
+      weight_feed: 'application/vnd.com.runkeeper.WeightFeed+json',
+      weight: 'application/vnd.com.runkeeper.Weight+json',
+      general_measurement_feed: 'application/vnd.com.runkeeper.GeneralMeasurementFeed+json',
+      general_measurement: 'application/vnd.com.runkeeper.GeneralMeasurement+json',
+      diabetes_feed: 'application/vnd.com.runkeeper.DiabetesFeed+json',
+      diatetes_measurement: 'application/vnd.com.runkeeper.DiabetesMeasurement+json',
+      records: 'application/vnd.com.runkeeper.Records+json',
+      profile: 'application/vnd.com.runkeeper.Profile+json',
+      settings: 'application/vnd.com.runkeeper.Settings+json'
     }.freeze
-  
+
     attr_accessor *VALID_OPTIONS_KEYS
-  
+
     def self.extended(base)
       base.reset
     end
-      
+
     def configure
       yield self
     end
-  
+
     def options
       options = {}
-      VALID_OPTIONS_KEYS.each{|k| options[k] = send(k)}
+      VALID_OPTIONS_KEYS.each { |k| options[k] = send(k) }
       options
     end
-  
+
     def reset
       self.client_id = DEFAULT_CLIENT_ID
       self.client_secret = DEFAULT_CLIENT_SECRET
@@ -66,7 +67,7 @@ module HealthGraph
       self.access_token_url = DEFAULT_ACCESS_TOKEN_URL
       self.authorization_redirect_url = DEFAULT_AUTHORIZATION_REDIRECT_URL
       self.endpoint = DEFAULT_ENDPOINT
-      self.adapter = DEFAULT_ADAPTER    
+      self.adapter = DEFAULT_ADAPTER
       self.faraday_options = DEFAULT_FARADAY_OPTIONS
       self.accept_headers = DEFAULT_ACCEPT_HEADERS
       self

--- a/lib/health_graph/model.rb
+++ b/lib/health_graph/model.rb
@@ -1,42 +1,39 @@
 module HealthGraph
   module Model
     include API
-  
+
     attr_accessor :body
-    
+
     def self.included(includer)
-      includer.extend ClassMethods          
+      includer.extend ClassMethods
     end
-        
+
     module ClassMethods
-      def from_hash(hash) 
+      def from_hash(hash)
         instance = new(hash)
         yield instance if block_given?
         instance
       end
-      
+
       def hash_attr_accessor(*symbols)
         attr_writer(*symbols)
         symbols.each do |symbol|
-          define_method(symbol) do            
+          define_method(symbol) do
             instance_variable_get("@#{symbol}")
           end
         end
       end
     end
-    
+
     def populate_from_hash!(hash)
       return unless hash
-      
+
       hash.each do |key, value|
         set_attr_method = "#{key}="
         unless value.nil?
-          if respond_to?(set_attr_method)
-            self.__send__(set_attr_method, value)
-          end
+          __send__(set_attr_method, value) if respond_to?(set_attr_method)
         end
       end
     end
-      
   end
 end

--- a/lib/health_graph/models/fitness_activities_feed.rb
+++ b/lib/health_graph/models/fitness_activities_feed.rb
@@ -1,24 +1,24 @@
 module HealthGraph
   class FitnessActivitiesFeed
-    include Model              
-    
+    include Model
+
     hash_attr_accessor :items, :next, :previous, :size
-    
-    class Item 
-      include Model      
-      
+
+    class Item
+      include Model
+
       hash_attr_accessor :type, :start_time, :total_distance, :duration, :uri
-      
-      def initialize(hash) 
+
+      def initialize(hash)
         populate_from_hash! hash
-      end      
+      end
     end
-                      
-    def initialize(access_token, path, params = {})            
+
+    def initialize(access_token, path, params = {})
       self.access_token = access_token
       response = get path, HealthGraph.accept_headers[:fitness_activity_feed], params
       self.body = response.body
-      populate_from_hash! self.body
-    end                           
+      populate_from_hash! body
+    end
   end
 end

--- a/lib/health_graph/models/fitness_activity_delete.rb
+++ b/lib/health_graph/models/fitness_activity_delete.rb
@@ -1,15 +1,15 @@
 module HealthGraph
   class FitnessActivityDelete
     include Model
-    
+
     hash_attr_accessor :location, :status
-    
-    def initialize access_token, params
+
+    def initialize(access_token, params)
       self.access_token = access_token
-      response = delete params["uri"], HealthGraph.accept_headers[:fitness_activity], params            
-           
+      response = delete params['uri'], HealthGraph.accept_headers[:fitness_activity], params
+
       self.location = response.headers[:location]
       self.status = response.status
     end
-  end  
+  end
 end

--- a/lib/health_graph/models/fitness_activity_update.rb
+++ b/lib/health_graph/models/fitness_activity_update.rb
@@ -1,15 +1,15 @@
 module HealthGraph
   class FitnessActivityUpdate
     include Model
-    
+
     hash_attr_accessor :location, :status
-    
-    def initialize access_token, params
+
+    def initialize(access_token, params)
       self.access_token = access_token
-      response = put params["uri"], HealthGraph.accept_headers[:fitness_activity], params            
-           
+      response = put params['uri'], HealthGraph.accept_headers[:fitness_activity], params
+
       self.location = response.headers[:location]
       self.status = response.status
     end
-  end  
+  end
 end

--- a/lib/health_graph/models/new_fitness_activity.rb
+++ b/lib/health_graph/models/new_fitness_activity.rb
@@ -1,15 +1,15 @@
 module HealthGraph
   class NewFitnessActivity
     include Model
-    
+
     hash_attr_accessor :location, :status
-    
-    def initialize access_token, params
+
+    def initialize(access_token, params)
       self.access_token = access_token
-      response = post "/fitnessActivities", HealthGraph.accept_headers[:new_fitness_activity], params            
-           
+      response = post '/fitnessActivities', HealthGraph.accept_headers[:new_fitness_activity], params
+
       self.location = response.headers[:location]
       self.status = response.status
     end
-  end  
+  end
 end

--- a/lib/health_graph/models/profile.rb
+++ b/lib/health_graph/models/profile.rb
@@ -1,18 +1,18 @@
 module HealthGraph
   class Profile
-    include Model              
-    
+    include Model
+
     hash_attr_accessor :location, :name, :gender, :athlete_type, :profile
-    
-    def initialize(access_token, path)            
+
+    def initialize(access_token, path)
       self.access_token = access_token
       response = get path, HealthGraph.accept_headers[:profile]
       self.body = response.body
-      populate_from_hash! self.body
-    end                   
-    
+      populate_from_hash! body
+    end
+
     def elite?
-      self.body["elite"] == "true"
+      body['elite'] == 'true'
     end
   end
 end

--- a/lib/health_graph/models/settings.rb
+++ b/lib/health_graph/models/settings.rb
@@ -1,18 +1,18 @@
 module HealthGraph
   class Settings
-    include Model              
-    
+    include Model
+
     hash_attr_accessor :distance_units, :weight_units
-    
-    def initialize(access_token, path)            
+
+    def initialize(access_token, path)
       self.access_token = access_token
       response = get path, HealthGraph.accept_headers[:settings]
       self.body = response.body
-      populate_from_hash! self.body
-    end                   
-    
+      populate_from_hash! body
+    end
+
     def elite?
-      self.body["elite"] == "true"
+      body['elite'] == 'true'
     end
   end
 end

--- a/lib/health_graph/models/sleep_feed.rb
+++ b/lib/health_graph/models/sleep_feed.rb
@@ -1,24 +1,24 @@
 module HealthGraph
   class SleepFeed
-    include Model              
-    
+    include Model
+
     hash_attr_accessor :items
-    
-    class Item 
-      include Model      
-      
+
+    class Item
+      include Model
+
       hash_attr_accessor :timestamp, :total_sleep, :times_woken, :rem, :deep, :light, :awake, :uri
-      
-      def initialize(hash) 
+
+      def initialize(hash)
         populate_from_hash! hash
-      end      
+      end
     end
-                      
-    def initialize(access_token, path)            
+
+    def initialize(access_token, path)
       self.access_token = access_token
       response = get path, HealthGraph.accept_headers[:sleep_feed]
       self.body = response.body
-      populate_from_hash! self.body                  
-    end                           
+      populate_from_hash! body
+    end
   end
 end

--- a/lib/health_graph/models/strength_training_activities_feed.rb
+++ b/lib/health_graph/models/strength_training_activities_feed.rb
@@ -1,24 +1,24 @@
 module HealthGraph
   class StrengthTrainingActivitiesFeed
-    include Model              
-    
+    include Model
+
     hash_attr_accessor :items, :next, :previous, :size
-    
+
     class Item
-      include Model 
-      
+      include Model
+
       hash_attr_accessor :start_time, :uri
-      
-      def initialize(hash) 
+
+      def initialize(hash)
         populate_from_hash! hash
-      end      
+      end
     end
-                      
-    def initialize(access_token, path, params = {})            
+
+    def initialize(access_token, path, params = {})
       self.access_token = access_token
       response = get path, HealthGraph.accept_headers[:strength_training_activity_feed], params
       self.body = response.body
-      populate_from_hash! self.body
+      populate_from_hash! body
     end
   end
 end

--- a/lib/health_graph/models/strength_training_activity.rb
+++ b/lib/health_graph/models/strength_training_activity.rb
@@ -1,8 +1,7 @@
 module HealthGraph
   class StrengthTrainingActivity
     include Model
-    
+
     hash_attr_accessor :uri, :start_time, :notes
   end
-  
 end

--- a/lib/health_graph/models/user.rb
+++ b/lib/health_graph/models/user.rb
@@ -1,50 +1,50 @@
 module HealthGraph
   class User
     include Model
-          
+
     hash_attr_accessor :userID
-     
-    def initialize(access_token)            
+
+    def initialize(access_token)
       self.access_token = access_token
-      response = get "user", HealthGraph.accept_headers[:user]
+      response = get 'user', HealthGraph.accept_headers[:user]
       self.body = response.body
-      populate_from_hash! self.body      
-    end
-        
-    def profile      
-      HealthGraph::Profile.new self.access_token, self.body["profile"]      
-    end        
-    
-    def settings
-      HealthGraph::Settings.new self.access_token, self.body["settings"]
-    end
-    
-    def weight
-      HealthGraph::WeightFeed.new self.access_token, self.body["weight"]
-    end
-    
-    def sleep
-      HealthGraph::SleepFeed.new self.access_token, self.body["sleep"]
-    end
-    
-    def fitness_activities params = {}
-      HealthGraph::FitnessActivitiesFeed.new self.access_token, self.body["fitness_activities"], params
-    end
-    
-    def new_fitness_activity params
-      HealthGraph::NewFitnessActivity.new self.access_token, params
-    end
-    
-    def fitness_activity_update params
-      HealthGraph::FitnessActivityUpdate.new self.access_token, params
+      populate_from_hash! body
     end
 
-    def fitness_activity_delete params
-      HealthGraph::FitnessActivityDelete.new self.access_token, params
+    def profile
+      HealthGraph::Profile.new access_token, body['profile']
     end
-    
-    def strength_training_activities params = {}
-      HealthGraph::StrengthTrainingActivitiesFeed.new self.access_token, self.body["strength_training_activities"], params
+
+    def settings
+      HealthGraph::Settings.new access_token, body['settings']
+    end
+
+    def weight
+      HealthGraph::WeightFeed.new access_token, body['weight']
+    end
+
+    def sleep
+      HealthGraph::SleepFeed.new access_token, body['sleep']
+    end
+
+    def fitness_activities(params = {})
+      HealthGraph::FitnessActivitiesFeed.new access_token, body['fitness_activities'], params
+    end
+
+    def new_fitness_activity(params)
+      HealthGraph::NewFitnessActivity.new access_token, params
+    end
+
+    def fitness_activity_update(params)
+      HealthGraph::FitnessActivityUpdate.new access_token, params
+    end
+
+    def fitness_activity_delete(params)
+      HealthGraph::FitnessActivityDelete.new access_token, params
+    end
+
+    def strength_training_activities(params = {})
+      HealthGraph::StrengthTrainingActivitiesFeed.new access_token, body['strength_training_activities'], params
     end
   end
 end

--- a/lib/health_graph/models/weight_feed.rb
+++ b/lib/health_graph/models/weight_feed.rb
@@ -1,24 +1,24 @@
 module HealthGraph
   class WeightFeed
-    include Model              
-    
+    include Model
+
     hash_attr_accessor :items
-    
-    class Item 
-      include Model      
-      
+
+    class Item
+      include Model
+
       hash_attr_accessor :timestamp, :weight, :free_mass, :mass_weight, :fat_percent, :bmi, :uri
-      
-      def initialize(hash) 
+
+      def initialize(hash)
         populate_from_hash! hash
-      end      
+      end
     end
-                      
-    def initialize(access_token, path)            
+
+    def initialize(access_token, path)
       self.access_token = access_token
       response = get path, HealthGraph.accept_headers[:weight_feed]
       self.body = response.body
-      populate_from_hash! self.body                  
-    end                           
+      populate_from_hash! body
+    end
   end
 end

--- a/test/health_graph/test_fitness_activities_feed.rb
+++ b/test/health_graph/test_fitness_activities_feed.rb
@@ -1,118 +1,111 @@
 require 'helper'
 
-class TestFitnessActivitiesFeed < Test::Unit::TestCase   
-    context "fitness activities" do 
-      setup do
-        stub_request(:get, HealthGraph.endpoint + '/user'
-          ).with(:header => { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}
-          ).to_return(:body => fixture('user_get.json'))
+class TestFitnessActivitiesFeed < Test::Unit::TestCase
+  context 'fitness activities' do
+    setup do
+      stub_request(:get, HealthGraph.endpoint + '/user').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }).to_return(body: fixture('user_get.json'))
 
-        stub_request(:get, HealthGraph.endpoint + '/fitnessActivities'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed]}
-          ).to_return(:body => fixture('fitness_activities_feed.json'))
-        
-        stub_request(:get, HealthGraph.endpoint + '/fitnessActivities?pageSize=3'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed]}
-          ).to_return(:body => fixture('fitness_activities_feed.json'))
+      stub_request(:get, HealthGraph.endpoint + '/fitnessActivities').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed] }).to_return(body: fixture('fitness_activities_feed.json'))
 
-        @user = HealthGraph::User.new(TEST_USER_TOKEN)
+      stub_request(:get, HealthGraph.endpoint + '/fitnessActivities?pageSize=3').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed] }).to_return(body: fixture('fitness_activities_feed.json'))
+
+      @user = HealthGraph::User.new(TEST_USER_TOKEN)
+    end
+
+    should 'make request to api' do
+      activities = @user.fitness_activities
+      assert_requested :get,  HealthGraph.endpoint + '/user', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }, times: 1
+      assert_requested :get,  HealthGraph.endpoint + '/fitnessActivities', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed] }, times: 1
+    end
+
+    should 'make request to api with params' do
+      @user.fitness_activities(pageSize: 3)
+      assert_requested :get, HealthGraph.endpoint + '/fitnessActivities?pageSize=3', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed] }, times: 1
+    end
+
+    should 'get body' do
+      expected = { 'items' =>
+        [{ 'duration' => 7920,
+           'total_distance' => 62_764.416,
+           'start_time' => 'Thu, 15 Sep 2011 13:28:59',
+           'type' => 'Cycling',
+           'uri' => '/fitnessActivities/52367938' },
+         { 'duration' => 1080,
+           'total_distance' => 2574.9504,
+           'start_time' => 'Thu, 15 Sep 2011 08:00:00',
+           'type' => 'Walking',
+           'uri' => '/fitnessActivities/52367984' },
+         { 'duration' => 2880,
+           'total_distance' => 7402.9824,
+           'start_time' => 'Wed, 14 Sep 2011 20:00:00',
+           'type' => 'Running',
+           'uri' => '/fitnessActivities/52368041' },
+         { 'duration' => 3060,
+           'total_distance' => 7724.8512,
+           'start_time' => 'Tue, 13 Sep 2011 20:00:00',
+           'type' => 'Running',
+           'uri' => '/fitnessActivities/52368120' },
+         { 'duration' => 4500,
+           'total_distance' => 5632.704,
+           'start_time' => 'Tue, 13 Sep 2011 08:00:00',
+           'type' => 'Running',
+           'uri' => '/fitnessActivities/52126193' }],
+                   'size' => 5 }
+
+      assert_equal expected, @user.fitness_activities.body
+    end
+
+    context 'item' do
+      should 'get items' do
+        expected = [{ 'duration' => 7920,
+                      'total_distance' => 62_764.416,
+                      'start_time' => 'Thu, 15 Sep 2011 13:28:59',
+                      'type' => 'Cycling',
+                      'uri' => '/fitnessActivities/52367938' },
+                    { 'duration' => 1080,
+                      'total_distance' => 2574.9504,
+                      'start_time' => 'Thu, 15 Sep 2011 08:00:00',
+                      'type' => 'Walking',
+                      'uri' => '/fitnessActivities/52367984' },
+                    { 'duration' => 2880,
+                      'total_distance' => 7402.9824,
+                      'start_time' => 'Wed, 14 Sep 2011 20:00:00',
+                      'type' => 'Running',
+                      'uri' => '/fitnessActivities/52368041' },
+                    { 'duration' => 3060,
+                      'total_distance' => 7724.8512,
+                      'start_time' => 'Tue, 13 Sep 2011 20:00:00',
+                      'type' => 'Running',
+                      'uri' => '/fitnessActivities/52368120' },
+                    { 'duration' => 4500,
+                      'total_distance' => 5632.704,
+                      'start_time' => 'Tue, 13 Sep 2011 08:00:00',
+                      'type' => 'Running',
+                      'uri' => '/fitnessActivities/52126193' }]
+
+        assert_equal expected, @user.fitness_activities.items
+        assert_equal 5, @user.fitness_activities.items.size
       end
-      
-      should "make request to api" do       
-        activities = @user.fitness_activities
-        assert_requested :get,  HealthGraph.endpoint + '/user', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}, :times => 1
-        assert_requested :get,  HealthGraph.endpoint + '/fitnessActivities', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed]}, :times => 1
-      end
-      
-      should "make request to api with params" do
-        @user.fitness_activities(:pageSize => 3)        
-        assert_requested :get,  HealthGraph.endpoint + '/fitnessActivities?pageSize=3', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:fitness_activities_feed]}, :times => 1
-      end
-      
-      should "get body" do
-        expected = {"items"=>
-          [{"duration"=>7920,
-            "total_distance"=>62764.416,
-            "start_time"=>"Thu, 15 Sep 2011 13:28:59",
-            "type"=>"Cycling",
-            "uri"=>"/fitnessActivities/52367938"},
-           {"duration"=>1080,
-            "total_distance"=>2574.9504,
-            "start_time"=>"Thu, 15 Sep 2011 08:00:00",
-            "type"=>"Walking",
-            "uri"=>"/fitnessActivities/52367984"},
-           {"duration"=>2880,
-            "total_distance"=>7402.9824,
-            "start_time"=>"Wed, 14 Sep 2011 20:00:00",
-            "type"=>"Running",
-            "uri"=>"/fitnessActivities/52368041"},
-           {"duration"=>3060,
-            "total_distance"=>7724.8512,
-            "start_time"=>"Tue, 13 Sep 2011 20:00:00",
-            "type"=>"Running",
-            "uri"=>"/fitnessActivities/52368120"},
-           {"duration"=>4500,
-            "total_distance"=>5632.704,
-            "start_time"=>"Tue, 13 Sep 2011 08:00:00",
-            "type"=>"Running",
-            "uri"=>"/fitnessActivities/52126193"}],
-         "size"=>5}
-        
-        assert_equal expected, @user.fitness_activities.body  
-      end   
-      
-      context "item" do
-        should "get items" do 
-          expected = [{"duration"=>7920,
-            "total_distance"=>62764.416,
-            "start_time"=>"Thu, 15 Sep 2011 13:28:59",
-            "type"=>"Cycling",
-            "uri"=>"/fitnessActivities/52367938"},
-           {"duration"=>1080,
-            "total_distance"=>2574.9504,
-            "start_time"=>"Thu, 15 Sep 2011 08:00:00",
-            "type"=>"Walking",
-            "uri"=>"/fitnessActivities/52367984"},
-           {"duration"=>2880,
-            "total_distance"=>7402.9824,
-            "start_time"=>"Wed, 14 Sep 2011 20:00:00",
-            "type"=>"Running",
-            "uri"=>"/fitnessActivities/52368041"},
-           {"duration"=>3060,
-            "total_distance"=>7724.8512,
-            "start_time"=>"Tue, 13 Sep 2011 20:00:00",
-            "type"=>"Running",
-            "uri"=>"/fitnessActivities/52368120"},
-           {"duration"=>4500,
-            "total_distance"=>5632.704,
-            "start_time"=>"Tue, 13 Sep 2011 08:00:00",
-            "type"=>"Running",
-            "uri"=>"/fitnessActivities/52126193"}]
-          
-          assert_equal expected, @user.fitness_activities.items
-          assert_equal 5, @user.fitness_activities.items.size
-        end                    
-        
-        should "get start time" do
-          assert_equal "Thu, 15 Sep 2011 13:28:59", @user.fitness_activities.items[0].start_time
-        end
 
-        should "get duration" do
-          assert_equal 7920, @user.fitness_activities.items[0].duration
-        end
-
-        should "get total distance" do
-          assert_equal 62764.416, @user.fitness_activities.items[0].total_distance
-        end
-
-        should "get type" do
-          assert_not_equal nil, @user.fitness_activities.items[0].type
-        end
-        
-        should "get uri" do
-          assert_not_equal nil, @user.fitness_activities.items[0].uri
-        end  
-                       
+      should 'get start time' do
+        assert_equal 'Thu, 15 Sep 2011 13:28:59', @user.fitness_activities.items[0].start_time
       end
-    end    
+
+      should 'get duration' do
+        assert_equal 7920, @user.fitness_activities.items[0].duration
+      end
+
+      should 'get total distance' do
+        assert_equal 62_764.416, @user.fitness_activities.items[0].total_distance
+      end
+
+      should 'get type' do
+        assert_not_equal nil, @user.fitness_activities.items[0].type
+      end
+
+      should 'get uri' do
+        assert_not_equal nil, @user.fitness_activities.items[0].uri
+      end
+    end
+  end
 end

--- a/test/health_graph/test_new_fitness_activity.rb
+++ b/test/health_graph/test_new_fitness_activity.rb
@@ -1,26 +1,24 @@
 require 'helper'
 
-class TestNewFitnessActivity < Test::Unit::TestCase  
-    context "New Fitness Activity" do 
-      setup do
-        stub_request(:post, HealthGraph.endpoint + '/fitnessActivities'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:new_fitness_activity]}
-          ).to_return(:status => 201, :headers => {'location' => '/fitnessActivities/20'})
-      end
-      
-      should "make request to api" do
-        activity = HealthGraph::NewFitnessActivity.new(TEST_USER_TOKEN, json_fixture('new_fitness_activity_params.json'))
-        assert_requested :post,  HealthGraph.endpoint + '/fitnessActivities', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:new_fitness_activity]}, :times => 1
-      end
-      
-      should "get location" do
-        activity = HealthGraph::NewFitnessActivity.new(TEST_USER_TOKEN, json_fixture('new_fitness_activity_params.json'))            
-        assert_equal '/fitnessActivities/20', activity.location    
-      end 
-      
-      should "get success status" do
-        activity = HealthGraph::NewFitnessActivity.new(TEST_USER_TOKEN, json_fixture('new_fitness_activity_params.json'))    
-        assert_equal 201, activity.status  
-      end            
-    end    
+class TestNewFitnessActivity < Test::Unit::TestCase
+  context 'New Fitness Activity' do
+    setup do
+      stub_request(:post, HealthGraph.endpoint + '/fitnessActivities').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:new_fitness_activity] }).to_return(status: 201, headers: { 'location' => '/fitnessActivities/20' })
+    end
+
+    should 'make request to api' do
+      activity = HealthGraph::NewFitnessActivity.new(TEST_USER_TOKEN, json_fixture('new_fitness_activity_params.json'))
+      assert_requested :post, HealthGraph.endpoint + '/fitnessActivities', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:new_fitness_activity] }, times: 1
+    end
+
+    should 'get location' do
+      activity = HealthGraph::NewFitnessActivity.new(TEST_USER_TOKEN, json_fixture('new_fitness_activity_params.json'))
+      assert_equal '/fitnessActivities/20', activity.location
+    end
+
+    should 'get success status' do
+      activity = HealthGraph::NewFitnessActivity.new(TEST_USER_TOKEN, json_fixture('new_fitness_activity_params.json'))
+      assert_equal 201, activity.status
+    end
+  end
 end

--- a/test/health_graph/test_profile.rb
+++ b/test/health_graph/test_profile.rb
@@ -1,59 +1,54 @@
 require 'helper'
 
 class TestProfile < Test::Unit::TestCase
-  context "profile" do        
+  context 'profile' do
     setup do
-      stub_request(:get, HealthGraph.endpoint + '/user'
-        ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}
-        ).to_return(:body => fixture('user_get.json'))
-      
-      stub_request(:get, HealthGraph.endpoint + '/profile'
-        ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:profile]}
-        ).to_return(:body => fixture('profile_get.json'))
-      
-      @user = HealthGraph::User.new(TEST_USER_TOKEN)      
-    end
-    
-    should "make request to api" do       
-      profile = @user.profile
-      assert_requested :get,  HealthGraph.endpoint + '/user', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}, :times => 1
-      assert_requested :get,  HealthGraph.endpoint + '/profile', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:profile]}, :times => 1
-    end
-    
-    should "get body" do
-      expected = {"location"=>"San Francisco, CA, USA",
-       "name"=>"Kenny Ma",
-       "elite"=>"true",
-       "gender"=>"M",
-       "athlete_type"=>"Runner",
-       "profile"=>"http://runkeeper.com/user/kennyma"}
+      stub_request(:get, HealthGraph.endpoint + '/user').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }).to_return(body: fixture('user_get.json'))
 
-              
+      stub_request(:get, HealthGraph.endpoint + '/profile').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:profile] }).to_return(body: fixture('profile_get.json'))
+
+      @user = HealthGraph::User.new(TEST_USER_TOKEN)
+    end
+
+    should 'make request to api' do
+      profile = @user.profile
+      assert_requested :get,  HealthGraph.endpoint + '/user', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }, times: 1
+      assert_requested :get,  HealthGraph.endpoint + '/profile', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:profile] }, times: 1
+    end
+
+    should 'get body' do
+      expected = { 'location' => 'San Francisco, CA, USA',
+                   'name' => 'Kenny Ma',
+                   'elite' => 'true',
+                   'gender' => 'M',
+                   'athlete_type' => 'Runner',
+                   'profile' => 'http://runkeeper.com/user/kennyma' }
+
       assert_equal expected, @user.profile.body
-    end                      
-    
-    should "get location" do
-      assert_equal "San Francisco, CA, USA", @user.profile.location
     end
-    
-    should "get name" do
-      assert_equal "Kenny Ma", @user.profile.name
+
+    should 'get location' do
+      assert_equal 'San Francisco, CA, USA', @user.profile.location
     end
-    
-    should "get elite" do
+
+    should 'get name' do
+      assert_equal 'Kenny Ma', @user.profile.name
+    end
+
+    should 'get elite' do
       assert_equal true, @user.profile.elite?
     end
-    
-    should "get gender" do
-      assert_equal "M", @user.profile.gender
+
+    should 'get gender' do
+      assert_equal 'M', @user.profile.gender
     end
-    
-    should "get authlete type" do
-      assert_equal "Runner", @user.profile.athlete_type
+
+    should 'get authlete type' do
+      assert_equal 'Runner', @user.profile.athlete_type
     end
-    
-    should "get profile url" do
-      assert_equal "http://runkeeper.com/user/kennyma", @user.profile.profile
+
+    should 'get profile url' do
+      assert_equal 'http://runkeeper.com/user/kennyma', @user.profile.profile
     end
   end
 end

--- a/test/health_graph/test_sleep_feed.rb
+++ b/test/health_graph/test_sleep_feed.rb
@@ -1,66 +1,62 @@
 require 'helper'
 
-class TestSleepFeed < Test::Unit::TestCase   
-    context "sleep" do 
-      setup do
-        stub_request(:get, HealthGraph.endpoint + '/user'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}
-          ).to_return(:body => fixture('user_get.json'))
+class TestSleepFeed < Test::Unit::TestCase
+  context 'sleep' do
+    setup do
+      stub_request(:get, HealthGraph.endpoint + '/user').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }).to_return(body: fixture('user_get.json'))
 
-        stub_request(:get, HealthGraph.endpoint + '/sleep'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:sleep_feed]}
-          ).to_return(:body => fixture('sleep_feed_get.json'))
+      stub_request(:get, HealthGraph.endpoint + '/sleep').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:sleep_feed] }).to_return(body: fixture('sleep_feed_get.json'))
 
-        @user = HealthGraph::User.new(TEST_USER_TOKEN)
-      end
-      
-      should "make request to api" do       
-        sleep = @user.sleep
-        assert_requested :get,  HealthGraph.endpoint + '/user', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}, :times => 1
-        assert_requested :get,  HealthGraph.endpoint + '/sleep', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:sleep_feed]}, :times => 1
-      end
-      
-      should "get body" do
-        expected = {"items"=>
-          [{"timestamp"=>"Thu, 22 Sep 2011 00:00:00",
-            "total_sleep"=>822,
-            "uri"=>"/sleep/6253947"},
-           {"timestamp"=>"Thu, 22 Sep 2011 00:00:00",
-            "uri"=>"/sleep/6253948",
-            "times_woken"=>29}],
-         "size"=>2}
-        
-        assert_equal expected, @user.sleep.body  
-      end   
-      
-      context "item" do
-        should "get items" do 
-          expected = [{"timestamp"=>"Thu, 22 Sep 2011 00:00:00",
-            "total_sleep"=>822,
-            "uri"=>"/sleep/6253947"},
-           {"timestamp"=>"Thu, 22 Sep 2011 00:00:00",
-            "uri"=>"/sleep/6253948",
-            "times_woken"=>29}]
-          
-          assert_equal expected, @user.sleep.items
-          assert_equal 2, @user.sleep.items.size
-        end              
-              
-        should "get timestamp" do
-          assert_equal "Thu, 22 Sep 2011 00:00:00", @user.sleep.items[0].timestamp
-        end
-      
-        should "get time sleep" do
-          assert_equal 822, @user.sleep.items[0].total_sleep
-        end
-        
-        should "get time woken" do
-          assert_equal 29, @user.sleep.items[1].times_woken
-        end
+      @user = HealthGraph::User.new(TEST_USER_TOKEN)
+    end
 
-        should "get uri" do
-          assert_equal "/sleep/6253947", @user.sleep.items[0].uri
-        end
+    should 'make request to api' do
+      sleep = @user.sleep
+      assert_requested :get,  HealthGraph.endpoint + '/user', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }, times: 1
+      assert_requested :get,  HealthGraph.endpoint + '/sleep', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:sleep_feed] }, times: 1
+    end
+
+    should 'get body' do
+      expected = { 'items' =>
+        [{ 'timestamp' => 'Thu, 22 Sep 2011 00:00:00',
+           'total_sleep' => 822,
+           'uri' => '/sleep/6253947' },
+         { 'timestamp' => 'Thu, 22 Sep 2011 00:00:00',
+           'uri' => '/sleep/6253948',
+           'times_woken' => 29 }],
+                   'size' => 2 }
+
+      assert_equal expected, @user.sleep.body
+    end
+
+    context 'item' do
+      should 'get items' do
+        expected = [{ 'timestamp' => 'Thu, 22 Sep 2011 00:00:00',
+                      'total_sleep' => 822,
+                      'uri' => '/sleep/6253947' },
+                    { 'timestamp' => 'Thu, 22 Sep 2011 00:00:00',
+                      'uri' => '/sleep/6253948',
+                      'times_woken' => 29 }]
+
+        assert_equal expected, @user.sleep.items
+        assert_equal 2, @user.sleep.items.size
       end
-    end    
+
+      should 'get timestamp' do
+        assert_equal 'Thu, 22 Sep 2011 00:00:00', @user.sleep.items[0].timestamp
+      end
+
+      should 'get time sleep' do
+        assert_equal 822, @user.sleep.items[0].total_sleep
+      end
+
+      should 'get time woken' do
+        assert_equal 29, @user.sleep.items[1].times_woken
+      end
+
+      should 'get uri' do
+        assert_equal '/sleep/6253947', @user.sleep.items[0].uri
+      end
+    end
+  end
 end

--- a/test/health_graph/test_user.rb
+++ b/test/health_graph/test_user.rb
@@ -1,40 +1,38 @@
 require 'helper'
 
-class TestUser < Test::Unit::TestCase  
-    context "user" do 
-      setup do
-        stub_request(:get, HealthGraph.endpoint + '/user'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}
-          ).to_return(:body => fixture('user_get.json'))
-      end
-      
-      should "make request to api" do
-         user = HealthGraph::User.new(TEST_USER_TOKEN)
-          assert_requested :get,  HealthGraph.endpoint + '/user', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}, :times => 1
-      end
-      
-      should "get body" do
-        expected = {"strength_training_activities"=>"/strengthTrainingActivities",
-         "weight"=>"/weight",
-         "settings"=>"/settings",
-         "diabetes"=>"/diabetes",
-         "team"=>"/team",
-         "sleep"=>"/sleep",
-         "fitness_activities"=>"/fitnessActivities",
-         "userID"=>5568845,
-         "nutrition"=>"/nutrition",
-         "general_measurements"=>"/generalMeasurements",
-         "background_activities"=>"/backgroundActivities",
-         "records"=>"/records",
-         "profile"=>"/profile"}
+class TestUser < Test::Unit::TestCase
+  context 'user' do
+    setup do
+      stub_request(:get, HealthGraph.endpoint + '/user').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }).to_return(body: fixture('user_get.json'))
+    end
 
-        user = HealthGraph::User.new(TEST_USER_TOKEN)        
-        assert_equal expected, user.body
-      end
-      
-      should "get user id" do
-        user = HealthGraph::User.new(TEST_USER_TOKEN)   
-        assert_equal 5568845, user.userID      
-      end              
-    end    
+    should 'make request to api' do
+      user = HealthGraph::User.new(TEST_USER_TOKEN)
+      assert_requested :get, HealthGraph.endpoint + '/user', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }, times: 1
+    end
+
+    should 'get body' do
+      expected = { 'strength_training_activities' => '/strengthTrainingActivities',
+                   'weight' => '/weight',
+                   'settings' => '/settings',
+                   'diabetes' => '/diabetes',
+                   'team' => '/team',
+                   'sleep' => '/sleep',
+                   'fitness_activities' => '/fitnessActivities',
+                   'userID' => 5_568_845,
+                   'nutrition' => '/nutrition',
+                   'general_measurements' => '/generalMeasurements',
+                   'background_activities' => '/backgroundActivities',
+                   'records' => '/records',
+                   'profile' => '/profile' }
+
+      user = HealthGraph::User.new(TEST_USER_TOKEN)
+      assert_equal expected, user.body
+    end
+
+    should 'get user id' do
+      user = HealthGraph::User.new(TEST_USER_TOKEN)
+      assert_equal 5_568_845, user.userID
+    end
+  end
 end

--- a/test/health_graph/test_weight_feed.rb
+++ b/test/health_graph/test_weight_feed.rb
@@ -1,56 +1,52 @@
 require 'helper'
 
-class TestWeightFeed < Test::Unit::TestCase   
-    context "weight" do 
-      setup do
-        stub_request(:get, HealthGraph.endpoint + '/user'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}
-          ).to_return(:body => fixture('user_get.json'))
+class TestWeightFeed < Test::Unit::TestCase
+  context 'weight' do
+    setup do
+      stub_request(:get, HealthGraph.endpoint + '/user').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }).to_return(body: fixture('user_get.json'))
 
-        stub_request(:get, HealthGraph.endpoint + '/weight'
-          ).with(:header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:weight_feed]}
-          ).to_return(:body => fixture('weight_feed_get.json'))
+      stub_request(:get, HealthGraph.endpoint + '/weight').with(header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:weight_feed] }).to_return(body: fixture('weight_feed_get.json'))
 
-        @user = HealthGraph::User.new(TEST_USER_TOKEN)
+      @user = HealthGraph::User.new(TEST_USER_TOKEN)
+    end
+
+    should 'make request to api' do
+      weight = @user.weight
+      assert_requested :get,  HealthGraph.endpoint + '/user', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user] }, times: 1
+      assert_requested :get,  HealthGraph.endpoint + '/weight', header: { 'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:weight_feed] }, times: 1
+    end
+
+    should 'get body' do
+      expected = { 'items' =>
+        [{ 'timestamp' => 'Mon, 10 Oct 2011 01:31:47',
+           'weight' => 63.502931853253,
+           'uri' => '/weight/6626834' }],
+                   'size' => 1 }
+
+      assert_equal expected, @user.weight.body
+    end
+
+    context 'item' do
+      should 'get one item' do
+        expected = [{ 'timestamp' => 'Mon, 10 Oct 2011 01:31:47',
+                      'weight' => 63.502931853253,
+                      'uri' => '/weight/6626834' }]
+
+        assert_equal expected, @user.weight.items
+        assert_equal 1, @user.weight.items.size
       end
-      
-      should "make request to api" do       
-        weight = @user.weight
-        assert_requested :get,  HealthGraph.endpoint + '/user', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:user]}, :times => 1
-        assert_requested :get,  HealthGraph.endpoint + '/weight', :header => {'Authorization' => 'Bearer ' + TEST_USER_TOKEN, 'Accept' => HealthGraph.accept_headers[:weight_feed]}, :times => 1
+
+      should 'get timestamp' do
+        assert_equal 'Mon, 10 Oct 2011 01:31:47', @user.weight.items[0].timestamp
       end
-      
-      should "get body" do
-        expected = {"items"=>
-          [{"timestamp"=>"Mon, 10 Oct 2011 01:31:47",
-            "weight"=>63.502931853253,
-            "uri"=>"/weight/6626834"}],
-         "size"=>1}
-        
-        assert_equal expected, @user.weight.body  
-      end   
-      
-      context "item" do
-        should "get one item" do 
-          expected = [{"timestamp"=>"Mon, 10 Oct 2011 01:31:47",
-            "weight"=>63.502931853253,
-            "uri"=>"/weight/6626834"}]
-          
-          assert_equal expected, @user.weight.items
-          assert_equal 1, @user.weight.items.size
-        end              
-              
-        should "get timestamp" do
-          assert_equal "Mon, 10 Oct 2011 01:31:47", @user.weight.items[0].timestamp
-        end
-      
-        should "get weight" do
-          assert_equal 63.502931853253, @user.weight.items[0].weight
-        end
-        
-        should "get uri" do
-          assert_equal "/weight/6626834", @user.weight.items[0].uri
-        end
+
+      should 'get weight' do
+        assert_equal 63.502931853253, @user.weight.items[0].weight
       end
-    end    
+
+      should 'get uri' do
+        assert_equal '/weight/6626834', @user.weight.items[0].uri
+      end
+    end
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,10 +10,10 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'health_graph'
 
 class Test::Unit::TestCase
-  TEST_USER_TOKEN = "b9aaf2581480432a939a72f894bf".freeze
+  TEST_USER_TOKEN = 'b9aaf2581480432a939a72f894bf'.freeze
 
   def fixture(file)
-    path = File.expand_path("../fixtures", __FILE__)
+    path = File.expand_path('../fixtures', __FILE__)
     File.new(path + '/' + file)
   end
 

--- a/test/test_health_graph.rb
+++ b/test/test_health_graph.rb
@@ -1,130 +1,130 @@
 require_relative 'helper'
 
 class TestHealthGraph < Test::Unit::TestCase
-  context "Health Graph" do
+  context 'Health Graph' do
     setup do
       HealthGraph.reset
     end
 
-    should "get default client id" do
+    should 'get default client id' do
       assert_equal nil, HealthGraph.client_id
     end
 
-    should "set client id" do
-      client_id = "123456asdb"
+    should 'set client id' do
+      client_id = '123456asdb'
       HealthGraph.client_id = client_id
       assert_equal client_id, HealthGraph.client_id
     end
 
-    should "get default client secret" do
+    should 'get default client secret' do
       assert_equal nil, HealthGraph.client_secret
     end
 
-    should "set client secret" do
-      secret = "supersecret"
+    should 'set client secret' do
+      secret = 'supersecret'
       HealthGraph.client_secret = secret
       assert_equal secret, HealthGraph.client_secret
     end
 
-    should "get default authorization url" do
-      assert_equal "https://runkeeper.com/apps/authorize", HealthGraph.authorization_url
+    should 'get default authorization url' do
+      assert_equal 'https://runkeeper.com/apps/authorize', HealthGraph.authorization_url
     end
 
-    should "set authorization url" do
-      url = "http://somesite.com/apps/authorize"
+    should 'set authorization url' do
+      url = 'http://somesite.com/apps/authorize'
       HealthGraph.authorization_url = url
       assert_equal url, HealthGraph.authorization_url
     end
 
-    should "get default access token url" do
-      assert_equal "https://runkeeper.com/apps/token", HealthGraph.access_token_url
+    should 'get default access token url' do
+      assert_equal 'https://runkeeper.com/apps/token', HealthGraph.access_token_url
     end
 
-    should "set access token url" do
-      url = "http://somesite.com/apps/token"
+    should 'set access token url' do
+      url = 'http://somesite.com/apps/token'
       HealthGraph.access_token_url = url
       assert_equal url, HealthGraph.access_token_url
     end
 
-    should "get default authorization redirect url" do
+    should 'get default authorization redirect url' do
       assert_equal nil, HealthGraph.authorization_redirect_url
     end
 
-    should "set authorization redirect url" do
-      url = "http://somesite.com/runkeeper"
+    should 'set authorization redirect url' do
+      url = 'http://somesite.com/runkeeper'
       HealthGraph.authorization_redirect_url = url
       assert_equal url, HealthGraph.authorization_redirect_url
     end
 
-    should "get default api endpoint" do
-      assert_equal "https://api.runkeeper.com", HealthGraph.endpoint
+    should 'get default api endpoint' do
+      assert_equal 'https://api.runkeeper.com', HealthGraph.endpoint
     end
 
-    should "set api endpoont" do
-      new_endpoint = "https://api.somesite.com"
+    should 'set api endpoont' do
+      new_endpoint = 'https://api.somesite.com'
       HealthGraph.endpoint = new_endpoint
       assert_equal new_endpoint, HealthGraph.endpoint
     end
 
-    should "get default adapter" do
+    should 'get default adapter' do
       assert_equal :net_http, HealthGraph.adapter
     end
 
-    should "set adapter" do
+    should 'set adapter' do
       adapter = :typhoeus
       HealthGraph.adapter = adapter
       assert_equal adapter, HealthGraph.adapter
     end
 
-    should "get default faraday options" do
+    should 'get default faraday options' do
       assert HealthGraph.faraday_options.empty?, "Expected empty hash but got #{HealthGraph.faraday_options.inspect}"
     end
 
-    should "set faraday options" do
-      options = {:new_option => "testing option", :another => "another option"}
+    should 'set faraday options' do
+      options = { new_option: 'testing option', another: 'another option' }
       HealthGraph.faraday_options = options
       assert_equal options, HealthGraph.faraday_options
     end
 
-    should "get default accept headers" do
+    should 'get default accept headers' do
       options = {
-        :user => "application/vnd.com.runkeeper.User+json",
-        :fitness_activity_feed => "application/vnd.com.runkeeper.FitnessActivityFeed+json",
-        :fitness_activity => "application/vnd.com.runkeeper.FitnessActivity+json",
-        :new_fitness_activity => "application/vnd.com.runkeeper.NewFitnessActivity+json",
-        :strength_training_activity_feed => "application/vnd.com.runkeeper.StrengthTrainingActivityFeed+json",
-        :strength_training_activity => "application/vnd.com.runkeeper.StrengthTrainingActivity+json",
-        :background_activity_feed => "application/vnd.com.runkeeper.BackgroundActivityFeed+json",
-        :background_activity => "application/vnd.com.runkeeper.BackgroundActivity+json",
-        :sleep_feed => "application/vnd.com.runkeeper.SleepFeed+json",
-        :sleep => "application/vnd.com.runkeeper.Sleep+json",
-        :nutrition_feed => "application/vnd.com.runkeeper.NutritionFeed+json",
-        :nutrition => "application/vnd.com.runkeeper.Nutrition+json",
-        :weight_feed => "application/vnd.com.runkeeper.WeightFeed+json",
-        :weight => "application/vnd.com.runkeeper.Weight+json",
-        :general_measurement_feed => "application/vnd.com.runkeeper.GeneralMeasurementFeed+json",
-        :general_measurement => "application/vnd.com.runkeeper.GeneralMeasurement+json",
-        :diabetes_feed => "application/vnd.com.runkeeper.DiabetesFeed+json",
-        :diatetes_measurement => "application/vnd.com.runkeeper.DiabetesMeasurement+json",
-        :records => "application/vnd.com.runkeeper.Records+json",
-        :profile => "application/vnd.com.runkeeper.Profile+json",
-        :settings=>"application/vnd.com.runkeeper.Settings+json"
+        user: 'application/vnd.com.runkeeper.User+json',
+        fitness_activity_feed: 'application/vnd.com.runkeeper.FitnessActivityFeed+json',
+        fitness_activity: 'application/vnd.com.runkeeper.FitnessActivity+json',
+        new_fitness_activity: 'application/vnd.com.runkeeper.NewFitnessActivity+json',
+        strength_training_activity_feed: 'application/vnd.com.runkeeper.StrengthTrainingActivityFeed+json',
+        strength_training_activity: 'application/vnd.com.runkeeper.StrengthTrainingActivity+json',
+        background_activity_feed: 'application/vnd.com.runkeeper.BackgroundActivityFeed+json',
+        background_activity: 'application/vnd.com.runkeeper.BackgroundActivity+json',
+        sleep_feed: 'application/vnd.com.runkeeper.SleepFeed+json',
+        sleep: 'application/vnd.com.runkeeper.Sleep+json',
+        nutrition_feed: 'application/vnd.com.runkeeper.NutritionFeed+json',
+        nutrition: 'application/vnd.com.runkeeper.Nutrition+json',
+        weight_feed: 'application/vnd.com.runkeeper.WeightFeed+json',
+        weight: 'application/vnd.com.runkeeper.Weight+json',
+        general_measurement_feed: 'application/vnd.com.runkeeper.GeneralMeasurementFeed+json',
+        general_measurement: 'application/vnd.com.runkeeper.GeneralMeasurement+json',
+        diabetes_feed: 'application/vnd.com.runkeeper.DiabetesFeed+json',
+        diatetes_measurement: 'application/vnd.com.runkeeper.DiabetesMeasurement+json',
+        records: 'application/vnd.com.runkeeper.Records+json',
+        profile: 'application/vnd.com.runkeeper.Profile+json',
+        settings: 'application/vnd.com.runkeeper.Settings+json'
       }
 
       assert_equal options, HealthGraph.accept_headers
     end
 
-    should "set accept headers" do
+    should 'set accept headers' do
       options = {
-        :user => "application/vnd.com.runkeeper.User+json",
-        :fitness_activity_feed => "application/vnd.com.runkeeper.FitnessActivityFeed+json",
+        user: 'application/vnd.com.runkeeper.User+json',
+        fitness_activity_feed: 'application/vnd.com.runkeeper.FitnessActivityFeed+json'
       }
 
       HealthGraph.accept_headers = options
       assert_equal options, HealthGraph.accept_headers
     end
 
-    context "configure" do
+    context 'configure' do
       HealthGraph::Configuration::VALID_OPTIONS_KEYS.each do |k|
         should "set #{k}" do
           HealthGraph.configure do |config|


### PR DESCRIPTION
Adds and run `rubocop --autocorrect` to automatically fix mainly style offenses (extra whitespace, missing newlines, pre-Ruby 1.9 hash syntax, single quotes etc)